### PR TITLE
DEVOP-587: add historical secrets sweep automation

### DIFF
--- a/scripts/secrets-sweep.sh
+++ b/scripts/secrets-sweep.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# DEVOP-587 — one-off historical secrets sweep across the org.
+#
+# Runs trufflehog + gitleaks against the full git history of every repo
+# in `allora-network` and writes JSON reports per repo.
+#
+# Usage:
+#   export GH_TOKEN=<a read-only PAT with `repo` scope, NOT GH_READONLY_PAT
+#                    (which is org-wide and we're rotating per DEVOP-586)>
+#   bash scripts/secrets-sweep.sh
+#
+# Run inside an ephemeral VM/container with NO other secrets present.
+# All outputs land in /tmp/sweep — tar them up, hand the bundle to a
+# triage owner, then `shred` the VM.
+
+set -euo pipefail
+
+ORG="${ORG:-allora-network}"
+OUT="${OUT:-/tmp/sweep}"
+CLONES="${CLONES:-/tmp/clones}"
+
+command -v trufflehog >/dev/null || { echo "trufflehog not installed (brew install trufflehog)"; exit 1; }
+command -v gitleaks   >/dev/null || { echo "gitleaks not installed (brew install gitleaks)"; exit 1; }
+command -v gh         >/dev/null || { echo "gh not installed"; exit 1; }
+command -v jq         >/dev/null || { echo "jq not installed"; exit 1; }
+
+mkdir -p "$OUT" "$CLONES"
+
+echo ">> fetching repo list for $ORG"
+mapfile -t REPOS < <(gh repo list "$ORG" --limit 300 --json name -q '.[].name' | sort)
+echo ">> $(echo ${#REPOS[@]}) repos to scan"
+
+i=0
+for repo in "${REPOS[@]}"; do
+  i=$((i+1))
+  echo ""
+  echo "[$i/${#REPOS[@]}] $repo"
+  # Skip archived repos? trufflehog is fast enough that we scan all.
+
+  # trufflehog: scan remote directly, only verified
+  trufflehog git "https://github.com/$ORG/$repo" \
+    --only-verified --json --no-update \
+    > "$OUT/$repo.trufflehog.jsonl" 2>"$OUT/$repo.trufflehog.err" || \
+    echo "  trufflehog exit=$? (continuing)"
+
+  # gitleaks: needs a local clone (bare is fine, faster)
+  bare="$CLONES/$repo.git"
+  if [ ! -d "$bare" ]; then
+    git clone --quiet --bare "https://github.com/$ORG/$repo" "$bare" || {
+      echo "  clone failed; skipping gitleaks"; continue
+    }
+  fi
+  gitleaks detect --source "$bare" --no-banner \
+    --report-format json --report-path "$OUT/$repo.gitleaks.json" \
+    > "$OUT/$repo.gitleaks.log" 2>&1 || \
+    echo "  gitleaks exit=$? (continuing; non-zero exit = findings present, normal)"
+done
+
+echo ""
+echo ">> aggregating summary"
+{
+  echo "# DEVOP-587 sweep — $(date -u +%FT%TZ)"
+  echo ""
+  echo "## Counts per repo (verified trufflehog hits / gitleaks hits)"
+  echo "| repo | trufflehog verified | gitleaks findings |"
+  echo "| --- | ---: | ---: |"
+  for repo in "${REPOS[@]}"; do
+    th=$(wc -l <"$OUT/$repo.trufflehog.jsonl" 2>/dev/null || echo 0)
+    gl=$(jq -r 'length' "$OUT/$repo.gitleaks.json" 2>/dev/null || echo 0)
+    if [ "${th:-0}" != "0" ] || [ "${gl:-0}" != "0" ]; then
+      echo "| $repo | $th | $gl |"
+    fi
+  done
+} > "$OUT/SUMMARY.md"
+
+echo ""
+echo ">> done. report dir: $OUT"
+echo ">> review $OUT/SUMMARY.md first; rotate every verified credential immediately."

--- a/scripts/secrets-sweep.sh
+++ b/scripts/secrets-sweep.sh
@@ -5,8 +5,11 @@
 # in `allora-network` and writes JSON reports per repo.
 #
 # Usage:
-#   export GH_TOKEN=<a read-only PAT with `repo` scope, NOT GH_READONLY_PAT
-#                    (which is org-wide and we're rotating per DEVOP-586)>
+#   export GH_TOKEN=<fine-grained PAT, resource owner = allora-network,
+#                    all repositories, Contents:read + Metadata:read only.
+#                    Do NOT use a classic `repo`-scoped PAT (read+write),
+#                    and NOT GH_READONLY_PAT (org-wide, being rotated per
+#                    DEVOP-586). See security/SECRETS-SWEEP-RUNBOOK.md.>
 #   bash scripts/secrets-sweep.sh
 #
 # Run inside an ephemeral VM/container with NO other secrets present.

--- a/scripts/secrets-sweep.sh
+++ b/scripts/secrets-sweep.sh
@@ -78,12 +78,24 @@ for repo in "${REPOS[@]}"; do
     TRUFFLEHOG_ERRORS+=("$repo:$th_rc")
   fi
 
-  # gitleaks: needs a local clone (bare is fine, faster)
+  # gitleaks: needs a local clone (bare is fine, faster).
+  # On re-runs (monthly cadence) we must refresh existing clones —
+  # otherwise gitleaks silently scans stale history and misses any
+  # commits pushed since the last sweep, which is asymmetric with
+  # trufflehog (which always scans the remote directly) and produces
+  # exactly the wrong failure mode: a "clean" gitleaks row for a repo
+  # that gained a leaked credential since the last sweep.
   bare="$CLONES/$repo.git"
   if [ ! -d "$bare" ]; then
     if ! git clone --quiet --bare "https://github.com/$ORG/$repo" "$bare"; then
       echo "  clone failed; recording gitleaks scan error"
       GITLEAKS_ERRORS+=("$repo:clone-failed")
+      continue
+    fi
+  else
+    if ! git --git-dir="$bare" fetch --quiet --prune --force origin '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'; then
+      echo "  fetch failed on cached clone; recording gitleaks scan error"
+      GITLEAKS_ERRORS+=("$repo:fetch-failed")
       continue
     fi
   fi

--- a/scripts/secrets-sweep.sh
+++ b/scripts/secrets-sweep.sh
@@ -26,9 +26,33 @@ command -v jq         >/dev/null || { echo "jq not installed"; exit 1; }
 
 mkdir -p "$OUT" "$CLONES"
 
+# Track repos whose scans failed entirely (vs. completed-with-or-without findings).
+# We surface these as ERROR rows in the summary so they cannot be silently
+# treated as clean.
+declare -a TRUFFLEHOG_ERRORS=()
+declare -a GITLEAKS_ERRORS=()
+
 echo ">> fetching repo list for $ORG"
-mapfile -t REPOS < <(gh repo list "$ORG" --limit 300 --json name -q '.[].name' | sort)
-echo ">> $(echo ${#REPOS[@]}) repos to scan"
+# Fetch the repo list with explicit error detection. `mapfile < <(... | sort)`
+# loses the pipeline exit status of `gh` because the process substitution
+# is non-blocking and `set -o pipefail` doesn't cross the `< <(...)`
+# boundary. Stage to a temp file and check exit codes explicitly so an
+# auth/network failure cannot silently produce an empty repo list (which
+# would otherwise look like a successful 0-repo sweep).
+REPO_LIST_FILE="$(mktemp)"
+trap 'rm -f "$REPO_LIST_FILE"' EXIT
+if ! gh repo list "$ORG" --limit 300 --json name -q '.[].name' > "$REPO_LIST_FILE"; then
+  echo "ERROR: gh repo list failed for org=$ORG — refusing to run a 0-repo sweep." >&2
+  echo "       Check that GH_TOKEN is set, scoped, and not rate-limited." >&2
+  exit 2
+fi
+mapfile -t REPOS < <(sort "$REPO_LIST_FILE")
+if [ "${#REPOS[@]}" -eq 0 ]; then
+  echo "ERROR: gh repo list returned zero repos for org=$ORG." >&2
+  echo "       This almost certainly means a credential/permission problem; refusing to proceed." >&2
+  exit 2
+fi
+echo ">> ${#REPOS[@]} repos to scan"
 
 i=0
 for repo in "${REPOS[@]}"; do
@@ -37,42 +61,121 @@ for repo in "${REPOS[@]}"; do
   echo "[$i/${#REPOS[@]}] $repo"
   # Skip archived repos? trufflehog is fast enough that we scan all.
 
-  # trufflehog: scan remote directly, only verified
+  # trufflehog: scan remote directly, only verified.
+  # Capture exit explicitly so we can flag scan failures in the summary
+  # rather than have them silently render as "0 findings".
+  set +e
   trufflehog git "https://github.com/$ORG/$repo" \
     --only-verified --json --no-update \
-    > "$OUT/$repo.trufflehog.jsonl" 2>"$OUT/$repo.trufflehog.err" || \
-    echo "  trufflehog exit=$? (continuing)"
+    > "$OUT/$repo.trufflehog.jsonl" 2>"$OUT/$repo.trufflehog.err"
+  th_rc=$?
+  set -e
+  if [ "$th_rc" -ne 0 ]; then
+    echo "  trufflehog exit=$th_rc (recorded as scan error)"
+    TRUFFLEHOG_ERRORS+=("$repo:$th_rc")
+  fi
 
   # gitleaks: needs a local clone (bare is fine, faster)
   bare="$CLONES/$repo.git"
   if [ ! -d "$bare" ]; then
-    git clone --quiet --bare "https://github.com/$ORG/$repo" "$bare" || {
-      echo "  clone failed; skipping gitleaks"; continue
-    }
+    if ! git clone --quiet --bare "https://github.com/$ORG/$repo" "$bare"; then
+      echo "  clone failed; recording gitleaks scan error"
+      GITLEAKS_ERRORS+=("$repo:clone-failed")
+      continue
+    fi
   fi
+  # gitleaks exits non-zero when findings are present, which is normal.
+  # We only treat exit codes >= 2 as scan errors (gitleaks convention:
+  # 0 = no leaks, 1 = leaks found, other = error). Anything else means
+  # the scan didn't complete and we must not count it as "0 findings".
+  set +e
   gitleaks detect --source "$bare" --no-banner \
     --report-format json --report-path "$OUT/$repo.gitleaks.json" \
-    > "$OUT/$repo.gitleaks.log" 2>&1 || \
-    echo "  gitleaks exit=$? (continuing; non-zero exit = findings present, normal)"
+    > "$OUT/$repo.gitleaks.log" 2>&1
+  gl_rc=$?
+  set -e
+  if [ "$gl_rc" -ge 2 ]; then
+    echo "  gitleaks exit=$gl_rc (recorded as scan error)"
+    GITLEAKS_ERRORS+=("$repo:$gl_rc")
+  fi
 done
 
 echo ""
 echo ">> aggregating summary"
+
+# Build quick-lookup sets of repos whose scans errored so we can surface
+# them in the summary as ERROR rather than a zero-finding row.
+declare -A TRUFFLEHOG_ERR_SET=()
+for entry in "${TRUFFLEHOG_ERRORS[@]:-}"; do
+  [ -z "$entry" ] && continue
+  TRUFFLEHOG_ERR_SET["${entry%%:*}"]="${entry#*:}"
+done
+declare -A GITLEAKS_ERR_SET=()
+for entry in "${GITLEAKS_ERRORS[@]:-}"; do
+  [ -z "$entry" ] && continue
+  GITLEAKS_ERR_SET["${entry%%:*}"]="${entry#*:}"
+done
+
 {
   echo "# DEVOP-587 sweep — $(date -u +%FT%TZ)"
   echo ""
+  echo "Scanned ${#REPOS[@]} repos. Scan errors: trufflehog=${#TRUFFLEHOG_ERR_SET[@]}, gitleaks=${#GITLEAKS_ERR_SET[@]}."
+  echo ""
   echo "## Counts per repo (verified trufflehog hits / gitleaks hits)"
+  echo ""
+  echo "An ERROR value means the scanner did not complete for that repo —"
+  echo "treat it as **unscanned**, NOT clean. See \`<repo>.trufflehog.err\`"
+  echo "or \`<repo>.gitleaks.log\` for the failure mode."
+  echo ""
   echo "| repo | trufflehog verified | gitleaks findings |"
   echo "| --- | ---: | ---: |"
   for repo in "${REPOS[@]}"; do
-    th=$(wc -l <"$OUT/$repo.trufflehog.jsonl" 2>/dev/null || echo 0)
-    gl=$(jq -r 'length' "$OUT/$repo.gitleaks.json" 2>/dev/null || echo 0)
-    if [ "${th:-0}" != "0" ] || [ "${gl:-0}" != "0" ]; then
+    if [ -n "${TRUFFLEHOG_ERR_SET[$repo]:-}" ]; then
+      th="ERROR(${TRUFFLEHOG_ERR_SET[$repo]})"
+    elif [ -s "$OUT/$repo.trufflehog.jsonl" ] || [ -f "$OUT/$repo.trufflehog.jsonl" ]; then
+      th=$(wc -l <"$OUT/$repo.trufflehog.jsonl" 2>/dev/null | tr -d ' ')
+      th="${th:-0}"
+    else
+      th="ERROR(missing-output)"
+    fi
+
+    if [ -n "${GITLEAKS_ERR_SET[$repo]:-}" ]; then
+      gl="ERROR(${GITLEAKS_ERR_SET[$repo]})"
+    elif [ -f "$OUT/$repo.gitleaks.json" ]; then
+      if gl_parsed=$(jq -r 'length' "$OUT/$repo.gitleaks.json" 2>/dev/null); then
+        gl="$gl_parsed"
+      else
+        gl="ERROR(unparseable-report)"
+      fi
+    else
+      gl="ERROR(missing-report)"
+    fi
+
+    # Surface every non-zero/non-clean row. A clean row (0/0) is omitted
+    # to keep the summary readable; ERROR rows are always surfaced.
+    if [ "$th" != "0" ] || [ "$gl" != "0" ]; then
       echo "| $repo | $th | $gl |"
     fi
   done
+
+  if [ "${#TRUFFLEHOG_ERR_SET[@]}" -gt 0 ] || [ "${#GITLEAKS_ERR_SET[@]}" -gt 0 ]; then
+    echo ""
+    echo "## Scan errors — must be re-run before declaring this sweep complete"
+    echo ""
+    for repo in "${!TRUFFLEHOG_ERR_SET[@]}"; do
+      echo "- trufflehog: $repo (exit=${TRUFFLEHOG_ERR_SET[$repo]})"
+    done
+    for repo in "${!GITLEAKS_ERR_SET[@]}"; do
+      echo "- gitleaks: $repo (exit=${GITLEAKS_ERR_SET[$repo]})"
+    done
+  fi
 } > "$OUT/SUMMARY.md"
 
 echo ""
 echo ">> done. report dir: $OUT"
 echo ">> review $OUT/SUMMARY.md first; rotate every verified credential immediately."
+if [ "${#TRUFFLEHOG_ERR_SET[@]}" -gt 0 ] || [ "${#GITLEAKS_ERR_SET[@]}" -gt 0 ]; then
+  echo ">> WARNING: ${#TRUFFLEHOG_ERR_SET[@]} trufflehog and ${#GITLEAKS_ERR_SET[@]} gitleaks scan errors recorded."
+  echo ">>          Sweep is NOT complete until these repos are re-scanned."
+  exit 3
+fi

--- a/security/SECRETS-SWEEP-RUNBOOK.md
+++ b/security/SECRETS-SWEEP-RUNBOOK.md
@@ -12,7 +12,17 @@ This is the compensating control for not buying GitHub Advanced Security: a one-
 ## Pre-flight
 
 - [ ] Stand up a **single-purpose** VM or container. No other Allora credentials present. No SSH keys for production. No 1Password Connect. Just `gh`, `trufflehog`, `gitleaks`, `jq`, `git`.
-- [ ] Set `GH_TOKEN` to a read-only personal PAT scoped to `repo`. **Do not use `GH_READONLY_PAT`** — that org secret is being rotated per DEVOP-586.
+- [ ] Set `GH_TOKEN` to a **fine-grained personal access token** with:
+    - **Resource owner:** `allora-network`
+    - **Repository access:** *All repositories* (the sweep enumerates the full org)
+    - **Repository permissions** (read-only, nothing else):
+      - `Contents: Read-only`
+      - `Metadata: Read-only`
+    - No account permissions. No write permissions of any kind.
+
+    Do **not** use a classic PAT with the `repo` scope — that scope is read+write on every accessible repo and is overprovisioned for a sweep that must never write. Do **not** use `GH_READONLY_PAT` — that org secret is being rotated per DEVOP-586.
+
+    > A long-lived org-scoped fine-grained PAT is being provisioned under DEVOP-577 for the scheduled re-sweep workflow. Until that lands, generate a *personal* fine-grained PAT scoped per the above for the baseline run, and delete it immediately after triage.
 - [ ] Confirm disk: ~5 GB free for clones across 225 repos.
 
 ## Run

--- a/security/SECRETS-SWEEP-RUNBOOK.md
+++ b/security/SECRETS-SWEEP-RUNBOOK.md
@@ -1,0 +1,66 @@
+# Historical secrets sweep runbook — DEVOP-587
+
+This is the compensating control for not buying GitHub Advanced Security: a one-off (then monthly) trufflehog + gitleaks sweep across the full git history of every repo in `allora-network`. Cost: ~$0. Recovers ~95% of the value of GHAS historical secret scanning.
+
+## When to run
+
+- **Once now** as the baseline.
+- After every credential rotation (DEVOP-563) — confirms the rotated value no longer hits.
+- Monthly via cron (planned: scheduled workflow in this repo; see "Future work" below).
+- After any incident (DEVOP-573 tabletop).
+
+## Pre-flight
+
+- [ ] Stand up a **single-purpose** VM or container. No other Allora credentials present. No SSH keys for production. No 1Password Connect. Just `gh`, `trufflehog`, `gitleaks`, `jq`, `git`.
+- [ ] Set `GH_TOKEN` to a read-only personal PAT scoped to `repo`. **Do not use `GH_READONLY_PAT`** — that org secret is being rotated per DEVOP-586.
+- [ ] Confirm disk: ~5 GB free for clones across 225 repos.
+
+## Run
+
+```bash
+# from this repo root
+bash scripts/secrets-sweep.sh
+```
+
+Approximate runtime: 30–60 min depending on the size of monorepos like `allora-chain` and `eliza-allora-plugin`.
+
+## Triage
+
+The script writes everything to `/tmp/sweep`:
+- `SUMMARY.md` — a markdown table of repos with non-zero hits.
+- `<repo>.trufflehog.jsonl` — trufflehog raw output (one JSON object per line).
+- `<repo>.gitleaks.json` — gitleaks raw output.
+- `<repo>.trufflehog.err` / `<repo>.gitleaks.log` — stderr.
+
+Triage steps:
+
+1. Open `SUMMARY.md`. Sort by trufflehog verified count descending.
+2. For every **verified** trufflehog hit:
+   - The credential is currently active. Rotate immediately. Order matters — rotate before continuing the sweep so the value in subsequent commits doesn't keep being "verified".
+   - Mark the row in the tracking spreadsheet (link from SECURITY-RUNBOOK.md) as "rotated YYYY-MM-DD by @handle".
+3. For every gitleaks hit that trufflehog didn't verify:
+   - Spot-check the commit and surrounding code. Common false positives: example fixtures, test wallets, public mainnet addresses.
+   - If real but inactive, document and rotate anyway (defense in depth).
+4. After all hits triaged, tar `/tmp/sweep` and store in a **password-protected** archive in 1Password (or equivalent). The raw output contains actual secret values until rotated.
+5. `shred -uvz /tmp/sweep/*; shred -uvz /tmp/clones/<repo>.git/* 2>/dev/null; rm -rf /tmp/sweep /tmp/clones`.
+6. **Tear down the VM** (do not reuse).
+
+## Output of the baseline run
+
+When the baseline runs, paste the contents of `SUMMARY.md` into the comment thread on DEVOP-587 (Linear). Do **not** include any actual secret values — just counts.
+
+## Future work
+
+- Scheduled monthly re-sweep — small workflow in this repo that runs the script on a GitHub-hosted runner, uploads the encrypted bundle to a private GCS bucket, and posts SUMMARY.md to Slack `#sec-ops`. Gated on:
+  - `GH_TOKEN` provisioning as a read-only org-scoped fine-grained PAT (DEVOP-577).
+  - A private GCS bucket for the encrypted reports.
+- Add `secretscan-baseline.txt` (list of known false-positive commit SHAs) so monthly runs don't keep re-flagging the same fixtures.
+
+## Tools
+
+- `trufflehog` (≥3.x) — `brew install trufflehog`.
+- `gitleaks` (≥8.x) — `brew install gitleaks`.
+- `gh` — `brew install gh`.
+- `jq` — `brew install jq`.
+
+Reference: https://github.com/trufflesecurity/trufflehog · https://github.com/gitleaks/gitleaks


### PR DESCRIPTION
## Summary

Adds the tooling and runbook for DEVOP-587 — the compensating control for not licensing GitHub Advanced Security.

- `scripts/secrets-sweep.sh` — runs `trufflehog` + `gitleaks` against the full git history of every repo in `allora-network` (~225 repos), writes one JSON report per repo, then aggregates into `SUMMARY.md`.
- `security/SECRETS-SWEEP-RUNBOOK.md` — pre-flight, run, triage, and teardown procedure. Emphasizes isolating in an ephemeral VM with no other credentials present.

## What this is not

This PR adds the tooling, not the baseline-run results. The actual sweep (and any credential rotations triggered by it) is a follow-up operations task: a human runs the script on an ephemeral VM, triages findings, rotates verified credentials, then deletes the VM. The runbook covers each step in order.

## Why OSS instead of GHAS

DEVOP-576 decision: stay at Tier 0/1, skip GHAS. The trufflehog + gitleaks combo recovers ~95% of GHAS historical-scan value at ~$0 cost. Push protection for *new* commits is separately tracked by DEVOP-550.

## Related

- Linear: https://linear.app/alloralabs/issue/DEVOP-587
- Companion: DEVOP-571 (SECURITY-RUNBOOK.md should link to this runbook).
- Future work: scheduled monthly re-sweep workflow — documented in the runbook but not implemented here (gated on a private GCS bucket + a read-only fine-grained org PAT).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds historical secrets sweep automation and a runbook to scan all `allora-network` repos with `trufflehog` and `gitleaks`, aggregate results into `SUMMARY.md`, and fail loud on scan errors. Requires a fine‑grained read‑only `GH_TOKEN` and refreshes cached clones so re-runs include new commits, delivering DEVOP-587’s compensating control for skipping GHAS.

- **New Features**
  - `scripts/secrets-sweep.sh` — lists org repos via `gh`, scans full history with `trufflehog --only-verified` and `gitleaks`, writes JSON reports to `/tmp/sweep` and an aggregated `SUMMARY.md`; refreshes cached bare clones before `gitleaks` to avoid stale scans on re-runs.
  - `security/SECRETS-SWEEP-RUNBOOK.md` — pre-flight, run, triage, teardown; mandates an ephemeral VM, a fine-grained read-only `GH_TOKEN` (Contents+Metadata only), and no other credentials; notes future monthly re-sweep.

- **Bug Fixes**
  - Refuse 0-repo runs: explicit `gh repo list` exit check and zero-repo guard.
  - Track per-repo exit codes; treat `gitleaks` exit >= 2 as a scan error.
  - `SUMMARY.md` shows `ERROR(code)` for failed scans, adds a “Scan errors” section, and the script exits non-zero if any errors are recorded.

<sup>Written for commit c7f76218d1af8430d592ecea86132d196e426b96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

